### PR TITLE
Updated Laraue.Core.Threading version to 6.0.5

### DIFF
--- a/src/Laraue.Core.Threading/Laraue.Core.Threading.csproj
+++ b/src/Laraue.Core.Threading/Laraue.Core.Threading.csproj
@@ -7,7 +7,7 @@
         <RepositoryType>git</RepositoryType>
         <Authors>Belyanskiy Ilya</Authors>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-        <Version>6.0.4</Version>
+        <Version>6.0.5</Version>
         <PackageProjectUrl>https://github.com/win7user10/Laraue.Core</PackageProjectUrl>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>


### PR DESCRIPTION
Updated Laraue.Core.Threading version to 6.0.5, which conveniently matches the version of dependency AsyncKeyedLock.

Over to you @win7user10 to package and release this, and then update the dependents to use this, namely [Laraue.Core.Telegram](https://www.nuget.org/packages/Laraue.Core.Telegram/) and [Laraue.Telegram.NET.Authentication](https://www.nuget.org/packages/Laraue.Telegram.NET.Authentication/).